### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -11,7 +11,7 @@ object Versions {
     const val activity = "1.5.1"
     const val fragment = "1.5.1"
     const val lifecycle = "2.5.1"
-    const val navigation = "2.5.0"
+    const val navigation = "2.5.1"
     const val dagger = "2.43"
     const val retrofit = "2.9.0"
     const val okHttp = "5.0.0-alpha.10"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -8,7 +8,7 @@ object Versions {
     const val constraintLayout = "2.1.4"
     const val vbpd = "1.5.6"
     const val core = "1.8.0"
-    const val activity = "1.5.0"
+    const val activity = "1.5.1"
     const val fragment = "1.5.0"
     const val lifecycle = "2.5.0"
     const val navigation = "2.5.0"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -9,7 +9,7 @@ object Versions {
     const val vbpd = "1.5.6"
     const val core = "1.8.0"
     const val activity = "1.5.1"
-    const val fragment = "1.5.0"
+    const val fragment = "1.5.1"
     const val lifecycle = "2.5.0"
     const val navigation = "2.5.0"
     const val dagger = "2.43"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -15,7 +15,7 @@ object Versions {
     const val dagger = "2.43"
     const val retrofit = "2.9.0"
     const val okHttp = "5.0.0-alpha.10"
-    const val room = "2.4.2"
+    const val room = "2.4.3"
     const val paging = "3.1.1"
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -10,7 +10,7 @@ object Versions {
     const val core = "1.8.0"
     const val activity = "1.5.1"
     const val fragment = "1.5.1"
-    const val lifecycle = "2.5.0"
+    const val lifecycle = "2.5.1"
     const val navigation = "2.5.0"
     const val dagger = "2.43"
     const val retrofit = "2.9.0"


### PR DESCRIPTION
Updated:
• [`Activity` version from 1.5.0 to 1.5.1](https://developer.android.com/jetpack/androidx/releases/activity#1.5.1)
• [`Fragment` version from 1.5.0 to 1.5.1](https://developer.android.com/jetpack/androidx/releases/fragment#1.5.1)
• [`Lifecycle` version from 2.5.0 to 2.5.1](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.5.1)
• [`Navigation` version from 2.5.0 to 2.5.1](https://developer.android.com/jetpack/androidx/releases/navigation#2.5.1)
• [`Room` version from 2.4.2 to 2.4.3](https://developer.android.com/jetpack/androidx/releases/room#2.4.3)