### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 object Versions {
 
-    const val AGP = "7.2.1"
+    const val AGP = "7.2.2"
     const val kotlin = "1.7.10"
     const val coroutines = "1.6.4"
     const val KSP = "1.7.10-1.0.6"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -12,7 +12,7 @@ object Versions {
     const val fragment = "1.5.1"
     const val lifecycle = "2.5.1"
     const val navigation = "2.5.1"
-    const val dagger = "2.43.1"
+    const val dagger = "2.43.2"
     const val retrofit = "2.9.0"
     const val okHttp = "5.0.0-alpha.10"
     const val room = "2.4.3"


### PR DESCRIPTION
Updated:
• [Android Gradle Plugin version from 7.2.1 to 7.2.2](https://developer.android.com/studio/releases/gradle-plugin#7-2-0)
• [Dagger version from 2.43.1 to 2.43.2](https://github.com/google/dagger/releases/tag/dagger-2.43.2)