### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -9,7 +9,7 @@ object Versions {
     const val vbpd = "1.5.6"
     const val core = "1.8.0"
     const val activity = "1.5.1"
-    const val fragment = "1.5.1"
+    const val fragment = "1.5.2"
     const val lifecycle = "2.5.1"
     const val navigation = "2.5.1"
     const val dagger = "2.43.2"


### PR DESCRIPTION
Updated:
• [`Fragment` version from 1.5.1 to 1.5.2](https://developer.android.com/jetpack/androidx/releases/fragment#1.5.2)