### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -7,7 +7,7 @@ object Versions {
     const val material = "1.8.0-alpha01"
     const val constraintLayout = "2.1.4"
     const val vbpd = "1.5.6"
-    const val core = "1.8.0"
+    const val core = "1.9.0"
     const val activity = "1.5.1"
     const val fragment = "1.5.2"
     const val lifecycle = "2.5.1"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -11,7 +11,7 @@ object Versions {
     const val activity = "1.5.1"
     const val fragment = "1.5.2"
     const val lifecycle = "2.5.1"
-    const val navigation = "2.5.1"
+    const val navigation = "2.5.2"
     const val dagger = "2.43.2"
     const val retrofit = "2.9.0"
     const val okHttp = "5.0.0-alpha.10"


### PR DESCRIPTION
Updated:
- [`Core` version from 1.8.0 to 1.9.0](https://developer.android.com/jetpack/androidx/releases/core#1.9.0)
- [`Navigation` version from 2.5.1 to 2.5.2](https://developer.android.com/jetpack/androidx/releases/navigation#2.5.2)