### PR TITLE
Updated AGP version

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 object Versions {
 
-    const val AGP = "7.2.2"
+    const val AGP = "7.3.0"
     const val kotlin = "1.7.10"
     const val coroutines = "1.6.4"
     const val KSP = "1.7.10-1.0.6"


### PR DESCRIPTION
Updated:
- [`Android Gradle Plugin` version from 7.2.2 to 7.3.0](https://developer.android.com/studio/releases/gradle-plugin#7-3-0)