### PR TITLE
Updated dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -8,7 +8,7 @@ object Versions {
     const val constraintLayout = "2.1.4"
     const val vbpd = "1.5.6"
     const val core = "1.9.0"
-    const val activity = "1.6.0"
+    const val activity = "1.6.1"
     const val fragment = "1.5.3"
     const val lifecycle = "2.5.1"
     const val navigation = "2.5.2"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -9,7 +9,7 @@ object Versions {
     const val vbpd = "1.5.6"
     const val core = "1.9.0"
     const val activity = "1.6.1"
-    const val fragment = "1.5.3"
+    const val fragment = "1.5.4"
     const val lifecycle = "2.5.1"
     const val navigation = "2.5.2"
     const val dagger = "2.44"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -11,7 +11,7 @@ object Versions {
     const val activity = "1.6.1"
     const val fragment = "1.5.4"
     const val lifecycle = "2.5.1"
-    const val navigation = "2.5.2"
+    const val navigation = "2.5.3"
     const val dagger = "2.44"
     const val retrofit = "2.9.0"
     const val okHttp = "5.0.0-alpha.10"


### PR DESCRIPTION
Updated:
- [`Activity version` from 1.6.0 to 1.6.1](https://developer.android.com/jetpack/androidx/releases/activity#1.6.1)
- [`Fragment version` from 1.5.3 to 1.5.4](https://developer.android.com/jetpack/androidx/releases/fragment#1.5.4)
- [`Navigation version` from 2.5.2 to 2.5.3](https://developer.android.com/jetpack/androidx/releases/navigation#2.5.3)