### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -9,7 +9,7 @@ object Versions {
     const val vbpd = "1.5.6"
     const val core = "1.9.0"
     const val activity = "1.6.1"
-    const val fragment = "1.5.4"
+    const val fragment = "1.5.5"
     const val lifecycle = "2.5.1"
     const val navigation = "2.5.3"
     const val dagger = "2.44.2"


### PR DESCRIPTION
Updated:
- [`Fragment` version from 1.5.4 to 1.5.5](https://developer.android.com/jetpack/androidx/releases/fragment#1.5.5)