### PR TITLE
Hotfix for doPagingRequest base method

### DIFF
--- a/data/src/main/kotlin/com/alish/boilerplate/data/base/BaseRepository.kt
+++ b/data/src/main/kotlin/com/alish/boilerplate/data/base/BaseRepository.kt
@@ -85,8 +85,8 @@ abstract class BaseRepository {
     /**
      * Do network paging request with default params
      */
-    protected fun <ValueDto : DataMapper<Value>, Value : Any> doPagingRequest(
-        pagingSource: BasePagingSource<ValueDto, Value>,
+    protected fun <ValueDto : DataMapper<Value>, Value : Any, PagingSource : BasePagingSource<ValueDto, Value>> doPagingRequest(
+        pagingSource: () -> PagingSource,
         pageSize: Int = 10,
         prefetchDistance: Int = pageSize,
         enablePlaceholders: Boolean = true,
@@ -104,7 +104,7 @@ abstract class BaseRepository {
                 jumpThreshold
             ),
             pagingSourceFactory = {
-                pagingSource
+                pagingSource()
             }
         ).flow
     }

--- a/data/src/main/kotlin/com/alish/boilerplate/data/repositories/FooRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/alish/boilerplate/data/repositories/FooRepositoryImpl.kt
@@ -16,5 +16,5 @@ class FooRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun fetchFooPaging() = doPagingRequest(FooPagingSource(service))
+    override fun fetchFooPaging() = doPagingRequest({ FooPagingSource(service) })
 }


### PR DESCRIPTION
When we use refresh() method in paging 3.1.0 version and higher app is crashing