### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,7 +1,7 @@
 object Versions {
 
     const val AGP = "7.3.1"
-    const val kotlin = "1.7.21"
+    const val kotlin = "1.8.0"
     const val coroutines = "1.6.4"
     const val KSP = "1.7.21-1.0.8"
     const val material = "1.7.0"


### PR DESCRIPTION
Updated:
- [`Kotlin` version from 1.7.21 to 1.8.0](https://github.com/JetBrains/kotlin/releases/tag/v1.8.0)