### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,7 +3,7 @@ object Versions {
     const val AGP = "7.3.1"
     const val kotlin = "1.8.0"
     const val coroutines = "1.6.4"
-    const val KSP = "1.7.21-1.0.8"
+    const val KSP = "1.8.0-1.0.8"
     const val material = "1.7.0"
     const val constraintLayout = "2.1.4"
     const val vbpd = "1.5.6"


### PR DESCRIPTION
Updated:
- [`KSP` version from 1.7.21-1.0.8 to 1.8.0-1.0.8](https://github.com/google/ksp/releases/tag/1.8.0-1.0.8)