### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -15,7 +15,7 @@ object Versions {
     const val dagger = "2.44.2"
     const val retrofit = "2.9.0"
     const val okHttp = "5.0.0-alpha.10"
-    const val room = "2.4.3"
+    const val room = "2.5.0"
     const val paging = "3.1.1"
 }
 


### PR DESCRIPTION
Updated:
- [`Room` version from 2.4.3 to 2.5.0](https://developer.android.com/jetpack/androidx/releases/room#2.5.0)