### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -4,7 +4,7 @@ object Versions {
     const val kotlin = "1.8.0"
     const val coroutines = "1.6.4"
     const val KSP = "1.8.0-1.0.8"
-    const val material = "1.7.0"
+    const val material = "1.8.0"
     const val constraintLayout = "2.1.4"
     const val vbpd = "1.5.6"
     const val core = "1.9.0"


### PR DESCRIPTION
Updated:
- [`Material Design Components` version from 1.7.0 to 1.8.0](https://github.com/material-components/material-components-android/releases/tag/1.8.0)