### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -14,7 +14,7 @@ object Versions {
     const val navigation = "2.5.3"
     const val dagger = "2.44.2"
     const val retrofit = "2.9.0"
-    const val okHttp = "5.0.0-alpha.10"
+    const val okHttp = "5.0.0-alpha.11"
     const val room = "2.5.0"
     const val paging = "3.1.1"
 }


### PR DESCRIPTION
Updated:
- [`OkHttp` version from 5.0.0-alpha.10 to 5.0.0-alpha.11](https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-500-alpha11)