### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -12,7 +12,7 @@ object Versions {
     const val fragment = "1.5.5"
     const val lifecycle = "2.5.1"
     const val navigation = "2.5.3"
-    const val dagger = "2.44.2"
+    const val dagger = "2.45"
     const val retrofit = "2.9.0"
     const val okHttp = "5.0.0-alpha.11"
     const val room = "2.5.0"


### PR DESCRIPTION
Updated:
- [`Dagger` version from 2.44.2 to 2.45](https://github.com/google/dagger/releases/tag/dagger-2.45)