### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 object Versions {
 
-    const val AGP = "7.4.1"
+    const val AGP = "7.4.2"
     const val kotlin = "1.8.10"
     const val coroutines = "1.6.4"
     const val KSP = "1.8.10-1.0.9"


### PR DESCRIPTION
Updated:
- [`Android Gradle Plugin` version from 7.4.1 to 7.4.2](https://developer.android.com/studio/releases/gradle-plugin#android-gradle-plugin-7.4.2-february-2023)