### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -15,7 +15,7 @@ object Versions {
     const val dagger = "2.45"
     const val retrofit = "2.9.0"
     const val okHttp = "5.0.0-alpha.11"
-    const val room = "2.5.0"
+    const val room = "2.5.1"
     const val paging = "3.1.1"
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -9,7 +9,7 @@ object Versions {
     const val vbpd = "1.5.8"
     const val core = "1.9.0"
     const val activity = "1.7.0"
-    const val fragment = "1.5.5"
+    const val fragment = "1.5.6"
     const val lifecycle = "2.6.0"
     const val navigation = "2.5.3"
     const val dagger = "2.45"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -8,7 +8,7 @@ object Versions {
     const val constraintLayout = "2.1.4"
     const val vbpd = "1.5.8"
     const val core = "1.9.0"
-    const val activity = "1.6.1"
+    const val activity = "1.7.0"
     const val fragment = "1.5.5"
     const val lifecycle = "2.6.0"
     const val navigation = "2.5.3"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -10,7 +10,7 @@ object Versions {
     const val core = "1.9.0"
     const val activity = "1.7.0"
     const val fragment = "1.5.6"
-    const val lifecycle = "2.6.0"
+    const val lifecycle = "2.6.1"
     const val navigation = "2.5.3"
     const val dagger = "2.45"
     const val retrofit = "2.9.0"


### PR DESCRIPTION
Updated:
- [`Activity` version from 1.6.1 to 1.7.0](https://developer.android.com/jetpack/androidx/releases/activity#1.7.0)
- [`Fragment` version to 1.5.5 to 1.5.6](https://developer.android.com/jetpack/androidx/releases/fragment#1.5.6)
- [`Lifecycle` version to 2.6.0 to 2.6.1](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.6.1)
- [`Room` version to 2.5.0 to 2.5.1](https://developer.android.com/jetpack/androidx/releases/room#2.5.1)