### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -6,7 +6,7 @@ object Versions {
     const val KSP = "1.8.10-1.0.9"
     const val material = "1.8.0"
     const val constraintLayout = "2.1.4"
-    const val vbpd = "1.5.8"
+    const val vbpd = "1.5.9"
     const val core = "1.9.0"
     const val activity = "1.7.0"
     const val fragment = "1.5.6"


### PR DESCRIPTION
Updated:
- [`ViewBindingPropertyDelegate` version from 1.5.8 to 1.5.9](https://github.com/androidbroadcast/ViewBindingPropertyDelegate/releases/tag/1.5.9)