### PR TITLE
Migrate to Android Studio Flamingo

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,6 +11,8 @@ plugins {
 }
 
 android {
+    namespace = Namespaces.app
+
     compileSdk = AndroidConfig.compileSdk
 
     defaultConfig {
@@ -42,9 +44,10 @@ android {
     kotlinOptions {
         jvmTarget = Options.kotlinOptions
     }
-
-    // View Binding
-    buildFeatures.viewBinding = true
+    buildFeatures {
+        buildConfig = true
+        viewBinding = true
+    }
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.alish.boilerplate">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -7,3 +7,9 @@ object AndroidConfig {
     const val release = "release"
     const val debug = "debug"
 }
+
+object Namespaces {
+
+    const val app = "com.alish.boilerplate"
+    const val data = "com.alish.boilerplate.data"
+}

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 object Versions {
 
-    const val AGP = "7.4.2"
+    const val AGP = "8.0.0"
     const val kotlin = "1.8.20"
     const val coroutines = "1.6.4"
     const val KSP = "1.8.20-1.0.10"

--- a/buildSrc/src/main/kotlin/Options.kt
+++ b/buildSrc/src/main/kotlin/Options.kt
@@ -2,6 +2,6 @@ import org.gradle.api.JavaVersion
 
 object Options {
 
-    val compileOptions = JavaVersion.VERSION_11
-    const val kotlinOptions = "11"
+    val compileOptions = JavaVersion.VERSION_17
+    const val kotlinOptions = "17"
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
 }
 
 android {
+    namespace = Namespaces.data
+
     compileSdk = AndroidConfig.compileSdk
 
     defaultConfig {
@@ -32,6 +34,10 @@ android {
     }
     kotlinOptions {
         jvmTarget = Options.kotlinOptions
+    }
+
+    buildFeatures {
+        buildConfig = true
     }
 }
 

--- a/data/src/main/AndroidManifest.xml
+++ b/data/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.alish.boilerplate.data" />
+<manifest />


### PR DESCRIPTION
Updated:
- [`Android Gradle Plugin` version from 7.4.2 to 8.0.0](https://developer.android.com/build/releases/gradle-plugin#8-0-0)
- `CompileOptions` & `KotlinOptions` to JavaVersion 17

Migrate to Flamingo
- Added `namespace` in modules `build.gradle`