### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,7 +3,7 @@ object Versions {
     const val AGP = "8.0.0"
     const val kotlin = "1.8.20"
     const val coroutines = "1.6.4"
-    const val KSP = "1.8.20-1.0.10"
+    const val KSP = "1.8.20-1.0.11"
     const val material = "1.8.0"
     const val constraintLayout = "2.1.4"
     const val vbpd = "1.5.9"


### PR DESCRIPTION
Updated:
-  [`KSP` version from 1.8.20-1.0.10 to 1.8.20-1.0.11](https://github.com/google/ksp/releases/tag/1.8.20-1.0.11)