### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,7 +1,7 @@
 object Versions {
 
     const val AGP = "8.0.0"
-    const val kotlin = "1.8.20"
+    const val kotlin = "1.8.21"
     const val coroutines = "1.6.4"
     const val KSP = "1.8.20-1.0.11"
     const val material = "1.8.0"


### PR DESCRIPTION
Updated:
- [`Kotlin` version from 1.8.20 to 1.8.21](https://github.com/JetBrains/kotlin/releases/tag/v1.8.21)