### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,7 +3,7 @@ object Versions {
     const val AGP = "8.0.0"
     const val kotlin = "1.8.21"
     const val coroutines = "1.6.4"
-    const val KSP = "1.8.20-1.0.11"
+    const val KSP = "1.8.21-1.0.11"
     const val material = "1.8.0"
     const val constraintLayout = "2.1.4"
     const val vbpd = "1.5.9"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,7 +2,7 @@ object Versions {
 
     const val AGP = "8.0.0"
     const val kotlin = "1.8.21"
-    const val coroutines = "1.6.4"
+    const val coroutines = "1.7.0-RC"
     const val KSP = "1.8.21-1.0.11"
     const val material = "1.8.0"
     const val constraintLayout = "2.1.4"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -13,7 +13,7 @@ object Versions {
     const val fragment = "1.5.7"
     const val lifecycle = "2.6.1"
     const val navigation = "2.5.3"
-    const val dagger = "2.45"
+    const val dagger = "2.46"
     const val retrofit = "2.9.0"
     const val moshi = "1.14.0"
     const val okHttp = "5.0.0-alpha.11"


### PR DESCRIPTION
Updated:
- [`KSP` version from 1.8.20-1.0.11 to 1.8.21-1.0.11](https://github.com/google/ksp/releases/tag/1.8.21-1.0.11)
- [`Dagger` version from 2.45 to 2.46](https://github.com/google/dagger/releases/tag/dagger-2.46)
- [`Kotlin Coroutines` version from 1.6.4 to 1.7.0-RC](https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.7.0-RC)