### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -8,7 +8,7 @@ object Versions {
     const val constraintLayout = "2.1.4"
     const val vbpd = "1.5.9"
     const val splashscreen = "1.0.1"
-    const val core = "1.9.0"
+    const val core = "1.10.0"
     const val activity = "1.7.1"
     const val fragment = "1.5.7"
     const val lifecycle = "2.6.1"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -4,7 +4,7 @@ object Versions {
     const val kotlin = "1.8.21"
     const val coroutines = "1.7.0-RC"
     const val KSP = "1.8.21-1.0.11"
-    const val material = "1.8.0"
+    const val material = "1.9.0-rc01"
     const val constraintLayout = "2.1.4"
     const val vbpd = "1.5.9"
     const val splashscreen = "1.0.1"


### PR DESCRIPTION
Updated:
- [`Core` version from 1.9.0 to 1.10.0](https://developer.android.com/jetpack/androidx/releases/core#1.10.0)
- [`Material Design Components` version from 1.8.0 to 1.9.0-rc01](https://github.com/material-components/material-components-android/releases/tag/1.9.0-rc01)