### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -12,7 +12,7 @@ object Versions {
     const val activity = "1.7.2"
     const val fragment = "1.6.0"
     const val lifecycle = "2.6.1"
-    const val navigation = "2.5.3"
+    const val navigation = "2.6.0"
     const val dagger = "2.46.1"
     const val retrofit = "2.9.0"
     const val moshi = "1.14.0"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,7 +3,7 @@ object Versions {
     const val AGP = "8.0.2"
     const val kotlin = "1.8.22"
     const val coroutines = "1.7.1"
-    const val KSP = "1.8.21-1.0.11"
+    const val KSP = "1.8.22-1.0.11"
     const val material = "1.9.0"
     const val constraintLayout = "2.1.4"
     const val vbpd = "1.5.9"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,7 +1,7 @@
 object Versions {
 
     const val AGP = "8.0.2"
-    const val kotlin = "1.8.21"
+    const val kotlin = "1.8.22"
     const val coroutines = "1.7.1"
     const val KSP = "1.8.21-1.0.11"
     const val material = "1.9.0"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -10,7 +10,7 @@ object Versions {
     const val core = "1.10.1"
     const val splashscreen = "1.0.1"
     const val activity = "1.7.2"
-    const val fragment = "1.5.7"
+    const val fragment = "1.6.0"
     const val lifecycle = "2.6.1"
     const val navigation = "2.5.3"
     const val dagger = "2.46.1"


### PR DESCRIPTION
Updated:
- [`Kotlin` version from 1.8.21 to 1.8.22](https://github.com/JetBrains/kotlin/releases/tag/v1.8.22)
- [`KSP` version from 1.8.21-1.0.11 to 1.8.22-1.0.11](https://github.com/google/ksp/releases/tag/1.8.22-1.0.11)
- [`Fragment` version from 1.5.7 to 1.6.0](https://developer.android.com/jetpack/androidx/releases/fragment#1.6.0)
- [`Navigation` version from 2.5.3 to 2.6.0](https://developer.android.com/jetpack/androidx/releases/navigation#2.6.0)