### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -17,7 +17,7 @@ object Versions {
     const val retrofit = "2.9.0"
     const val moshi = "1.14.0"
     const val okHttp = "5.0.0-alpha.11"
-    const val room = "2.5.1"
+    const val room = "2.5.2"
     const val paging = "3.1.1"
 }
 


### PR DESCRIPTION
Updated:
- [`Room` version from 2.5.1 to 2.5.2](https://developer.android.com/jetpack/androidx/releases/room#2.5.2)