### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -15,7 +15,7 @@ object Versions {
     const val navigation = "2.6.0"
     const val dagger = "2.46.1"
     const val retrofit = "2.9.0"
-    const val moshi = "1.14.0"
+    const val moshi = "1.15.0"
     const val okHttp = "5.0.0-alpha.11"
     const val room = "2.5.2"
     const val paging = "3.1.1"


### PR DESCRIPTION
Updated:
- [`Moshi` version from 1.14.0 to 1.15.0](https://github.com/square/moshi/blob/master/CHANGELOG.md#version-1150)