### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -13,7 +13,7 @@ object Versions {
     const val fragment = "1.6.0"
     const val lifecycle = "2.6.1"
     const val navigation = "2.6.0"
-    const val dagger = "2.46.1"
+    const val dagger = "2.47"
     const val retrofit = "2.9.0"
     const val moshi = "1.15.0"
     const val okHttp = "5.0.0-alpha.11"


### PR DESCRIPTION
Updated:
- [`Dagger` version from 2.46.1 to 2.47](https://github.com/google/dagger/releases/tag/dagger-2.47)