### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,7 +3,7 @@ object Versions {
     const val AGP = "8.0.2"
     const val kotlin = "1.9.0"
     const val coroutines = "1.7.2"
-    const val KSP = "1.9.0-1.0.11"
+    const val KSP = "1.9.0-1.0.12"
     const val material = "1.9.0"
     const val constraintLayout = "2.1.4"
     const val vbpd = "1.5.9"


### PR DESCRIPTION
Update:
- [`KSP` version from 1.9.0-1.0.11 to 1.9.0-1.0.12](https://github.com/google/ksp/releases/tag/1.9.0-1.0.12)