### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 object Versions {
 
-    const val AGP = "8.0.2"
+    const val AGP = "8.1.0"
     const val kotlin = "1.9.0"
     const val coroutines = "1.7.2"
     const val KSP = "1.9.0-1.0.12"


### PR DESCRIPTION
Updated:
- [`Android Gradle Plugin` version from 8.0.2 to 8.1.0](https://developer.android.com/build/releases/gradle-plugin#8-1-0)