### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -12,7 +12,7 @@ object Versions {
     const val activity = "1.7.2"
     const val fragment = "1.6.1"
     const val lifecycle = "2.6.1"
-    const val navigation = "2.6.0"
+    const val navigation = "2.7.0"
     const val dagger = "2.47"
     const val retrofit = "2.9.0"
     const val moshi = "1.15.0"


### PR DESCRIPTION
Updated:
- [`Navigation` version from 2.6.0 to 2.7.0](https://developer.android.com/jetpack/androidx/releases/navigation#2.7.0)