### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 object Versions {
 
-    const val AGP = "8.1.0"
+    const val AGP = "8.1.1"
     const val kotlin = "1.9.10"
     const val coroutines = "1.7.3"
     const val KSP = "1.9.0-1.0.13"


### PR DESCRIPTION
Updated:
- [`Android Gradle Plugin` version from 8.1.0 to 8.1.1](https://mvnrepository.com/artifact/com.android.tools.build/gradle/8.1.1)