### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -12,7 +12,7 @@ object Versions {
     const val activity = "1.7.2"
     const val fragment = "1.6.1"
     const val lifecycle = "2.6.1"
-    const val navigation = "2.7.0"
+    const val navigation = "2.7.1"
     const val dagger = "2.47"
     const val retrofit = "2.9.0"
     const val moshi = "1.15.0"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,7 +3,7 @@ object Versions {
     const val AGP = "8.1.1"
     const val kotlin = "1.9.10"
     const val coroutines = "1.7.3"
-    const val KSP = "1.9.0-1.0.13"
+    const val KSP = "1.9.10-1.0.13"
     const val material = "1.9.0"
     const val constraintLayout = "2.1.4"
     const val vbpd = "1.5.9"


### PR DESCRIPTION
Updated:
- [`KSP` version from 1.9.0-1.0.13 to 1.9.10-1.0.13](https://github.com/google/ksp/releases/tag/1.9.10-1.0.13)
- [`Navigation` version from 2.7.0 to 2.7.1](https://developer.android.com/jetpack/androidx/releases/navigation#2.7.1)