### PR TITLE
Update dependencies versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,9 @@ plugins {
 
     // Hilt
     id(Plugins.Hilt.android)
+
+    // KSP
+    id(Plugins.KSP.ksp)
 }
 
 android {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,5 +86,5 @@ dependencies {
 
     // Hilt
     implementation(Libraries.Hilt.android)
-    kapt(Libraries.Hilt.compiler)
+    ksp(Libraries.Hilt.compiler)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,9 @@ plugins {
     id(Plugins.AGP.library) version Versions.AGP apply false
     kotlin(Plugins.Kotlin.android) version Versions.kotlin apply false
 
+    // KSP
+    id(Plugins.KSP.ksp) version Versions.KSP apply false
+
     // Navigation Safe Args
     id(Plugins.Navigation.safeArgs) version Versions.navigation apply false
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -13,7 +13,7 @@ object Versions {
     const val fragment = "1.6.1"
     const val lifecycle = "2.6.1"
     const val navigation = "2.7.1"
-    const val dagger = "2.47"
+    const val dagger = "2.48"
     const val retrofit = "2.9.0"
     const val moshi = "1.15.0"
     const val okHttp = "5.0.0-alpha.11"

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -2,8 +2,8 @@ plugins {
     id(Plugins.AGP.library)
     kotlin(Plugins.Kotlin.android)
 
-    // Kotlin Symbol Processing
-    id(Plugins.KSP.ksp) version Versions.KSP
+    // KSP
+    id(Plugins.KSP.ksp)
 }
 
 android {


### PR DESCRIPTION
Updated:
- [`Dagger/Hilt` version from 2.47 to 2.48 and migrate from kapt to ksp](https://github.com/google/dagger/releases/tag/dagger-2.48)