### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -11,7 +11,7 @@ object Versions {
     const val splashscreen = "1.0.1"
     const val activity = "1.7.2"
     const val fragment = "1.6.1"
-    const val lifecycle = "2.6.1"
+    const val lifecycle = "2.6.2"
     const val navigation = "2.7.1"
     const val dagger = "2.48"
     const val retrofit = "2.9.0"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -12,7 +12,7 @@ object Versions {
     const val activity = "1.7.2"
     const val fragment = "1.6.1"
     const val lifecycle = "2.6.2"
-    const val navigation = "2.7.1"
+    const val navigation = "2.7.2"
     const val dagger = "2.48"
     const val retrofit = "2.9.0"
     const val moshi = "1.15.0"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -18,7 +18,7 @@ object Versions {
     const val moshi = "1.15.0"
     const val okHttp = "5.0.0-alpha.11"
     const val room = "2.5.2"
-    const val paging = "3.2.0"
+    const val paging = "3.2.1"
 }
 
 object Libraries {


### PR DESCRIPTION
Updated:
- [`Lifecycle` version from 2.6.1 to 2.6.2](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.6.2)
- [`Navigation` version from 2.7.1 to 2.7.2](https://developer.android.com/jetpack/androidx/releases/navigation#2.7.2)
- [`Paging` version from 3.2.0 to 3.2.1](https://developer.android.com/jetpack/androidx/releases/paging#3.2.1)