### PR TITLE
Update dependencies version

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -12,7 +12,7 @@ object Versions {
     const val activity = "1.7.2"
     const val fragment = "1.6.1"
     const val lifecycle = "2.6.2"
-    const val navigation = "2.7.2"
+    const val navigation = "2.7.3"
     const val dagger = "2.48"
     const val retrofit = "2.9.0"
     const val moshi = "1.15.0"


### PR DESCRIPTION
Updated:
- [`Navigation` version from 2.7.2 to 2.7.3](https://developer.android.com/jetpack/androidx/releases/navigation#2.7.3)