### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -4,7 +4,7 @@ object Versions {
     const val kotlin = "1.9.10"
     const val coroutines = "1.7.3"
     const val KSP = "1.9.10-1.0.13"
-    const val material = "1.9.0"
+    const val material = "1.10.0"
     const val constraintLayout = "2.1.4"
     const val vbpd = "1.5.9"
     const val core = "1.10.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip


### PR DESCRIPTION
Updated:
- [`Material Components` version from 1.9.0 to 1.10.0](https://github.com/material-components/material-components-android/releases/tag/1.10.0)
- [`Gradle` version from 8.3 to 8.4](https://docs.gradle.org/8.4/release-notes.html)