### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -12,7 +12,7 @@ object Versions {
     const val activity = "1.8.0"
     const val fragment = "1.6.2"
     const val lifecycle = "2.6.2"
-    const val navigation = "2.7.4"
+    const val navigation = "2.7.5"
     const val dagger = "2.48.1"
     const val retrofit = "2.9.0"
     const val moshi = "1.15.0"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -10,7 +10,7 @@ object Versions {
     const val core = "1.12.0"
     const val splashscreen = "1.0.1"
     const val activity = "1.8.0"
-    const val fragment = "1.6.1"
+    const val fragment = "1.6.2"
     const val lifecycle = "2.6.2"
     const val navigation = "2.7.4"
     const val dagger = "2.48.1"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,7 +1,7 @@
 object Versions {
 
     const val AGP = "8.1.2"
-    const val kotlin = "1.9.10"
+    const val kotlin = "1.9.20"
     const val coroutines = "1.7.3"
     const val KSP = "1.9.10-1.0.13"
     const val material = "1.10.0"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,7 +3,7 @@ object Versions {
     const val AGP = "8.1.2"
     const val kotlin = "1.9.20"
     const val coroutines = "1.7.3"
-    const val KSP = "1.9.10-1.0.13"
+    const val KSP = "1.9.20-1.0.14"
     const val material = "1.10.0"
     const val constraintLayout = "2.1.4"
     const val vbpd = "1.5.9"


### PR DESCRIPTION
Updated:
- [`Kotlin` version from 1.9.10 to 1.9.20](https://github.com/JetBrains/kotlin/releases/tag/v1.9.20)
- [`KSP` version from 1.9.10-1.0.13 to 1.9.20-1.0.14](https://github.com/google/ksp/releases/tag/1.9.20-1.0.14)
- [`Fragment` version from 1.6.1 to 1.6.2](https://developer.android.com/jetpack/androidx/releases/fragment#1.6.2)
- [`Navigation` version from 2.7.4 to 2.7.5](https://developer.android.com/jetpack/androidx/releases/navigation#2.7.5)