### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 object Versions {
 
-    const val AGP = "8.1.2"
+    const val AGP = "8.1.3"
     const val kotlin = "1.9.20"
     const val coroutines = "1.7.3"
     const val KSP = "1.9.20-1.0.14"


### PR DESCRIPTION
Updated:
- [`Android Gradle Plugin` version from 8.1.2 to 8.1.3](https://mvnrepository.com/artifact/com.android.tools.build/gradle/8.1.3)