### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,7 +1,7 @@
 object Versions {
 
     const val AGP = "8.1.4"
-    const val kotlin = "1.9.20"
+    const val kotlin = "1.9.21"
     const val coroutines = "1.7.3"
     const val KSP = "1.9.20-1.0.14"
     const val material = "1.10.0"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -17,7 +17,7 @@ object Versions {
     const val retrofit = "2.9.0"
     const val moshi = "1.15.0"
     const val okHttp = "5.0.0-alpha.11"
-    const val room = "2.6.0"
+    const val room = "2.6.1"
     const val paging = "3.2.1"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip


### PR DESCRIPTION
Updated:
- [`Kotlin` version from 1.9.20 to 1.9.21](https://github.com/JetBrains/kotlin/releases/tag/v1.9.21)
- [`Gradle` version from 8.4 to 8.5](https://github.com/gradle/gradle/releases/tag/v8.5.0)
- [`Room` version from 2.6.0 to 2.6.1](https://developer.android.com/jetpack/androidx/releases/room#2.6.1)