### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,7 +3,7 @@ object Versions {
     const val AGP = "8.1.4"
     const val kotlin = "1.9.21"
     const val coroutines = "1.7.3"
-    const val KSP = "1.9.20-1.0.14"
+    const val KSP = "1.9.21-1.0.15"
     const val material = "1.10.0"
     const val constraintLayout = "2.1.4"
     const val vbpd = "1.5.9"


### PR DESCRIPTION
Updated:
- [`KSP` version from 1.9.20-1.0.14 to 1.9.21-1.0.15](https://github.com/google/ksp/releases/tag/1.9.21-1.0.15)