### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 object Versions {
 
-    const val AGP = "8.1.4"
+    const val AGP = "8.2.0"
     const val kotlin = "1.9.21"
     const val coroutines = "1.7.3"
     const val KSP = "1.9.21-1.0.15"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -16,7 +16,7 @@ object Versions {
     const val dagger = "2.49"
     const val retrofit = "2.9.0"
     const val moshi = "1.15.0"
-    const val okHttp = "5.0.0-alpha.11"
+    const val okHttp = "4.12.0"
     const val room = "2.6.1"
     const val paging = "3.2.1"
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -13,7 +13,7 @@ object Versions {
     const val fragment = "1.6.2"
     const val lifecycle = "2.6.2"
     const val navigation = "2.7.5"
-    const val dagger = "2.48.1"
+    const val dagger = "2.49"
     const val retrofit = "2.9.0"
     const val moshi = "1.15.0"
     const val okHttp = "5.0.0-alpha.11"


### PR DESCRIPTION
Updated:
- [`AGP` version from 8.1.4 to 8.2.0](https://developer.android.com/build/releases/gradle-plugin#8-2-0) [(maven)](https://mvnrepository.com/artifact/com.android.tools.build/gradle/8.2.0)
- [`Dagger` version from 2.48.1 to 2.49](https://github.com/google/dagger/releases/tag/dagger-2.49)
- [`OkHttp` version from 5.0.0-alpha.11 to 4.12.0](https://square.github.io/okhttp/changelogs/changelog_4x/#version-4120)