### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -9,7 +9,7 @@ object Versions {
     const val vbpd = "1.5.9"
     const val core = "1.12.0"
     const val splashscreen = "1.0.1"
-    const val activity = "1.8.1"
+    const val activity = "1.8.2"
     const val fragment = "1.6.2"
     const val lifecycle = "2.6.2"
     const val navigation = "2.7.6"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 object Versions {
 
-    const val AGP = "8.2.0"
+    const val AGP = "8.1.4"
     const val kotlin = "1.9.21"
     const val coroutines = "1.7.3"
     const val KSP = "1.9.21-1.0.15"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -12,7 +12,7 @@ object Versions {
     const val activity = "1.8.1"
     const val fragment = "1.6.2"
     const val lifecycle = "2.6.2"
-    const val navigation = "2.7.5"
+    const val navigation = "2.7.6"
     const val dagger = "2.49"
     const val retrofit = "2.9.0"
     const val moshi = "1.15.0"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -4,7 +4,7 @@ object Versions {
     const val kotlin = "1.9.21"
     const val coroutines = "1.7.3"
     const val KSP = "1.9.21-1.0.15"
-    const val material = "1.10.0"
+    const val material = "1.11.0"
     const val constraintLayout = "2.1.4"
     const val vbpd = "1.5.9"
     const val core = "1.12.0"


### PR DESCRIPTION
- rollback `AGP` version from 8.2.0 to 8.1.4 for OkHttp 4.12.0

Updated:
- [`Material Components` version from 1.10.0 to 1.11.0](https://github.com/material-components/material-components-android/releases/tag/1.11.0)
- [`Navigation` version from 2.7.5 to 2.7.6](https://developer.android.com/jetpack/androidx/releases/navigation#2.7.6)
- [`Activity` version from 1.8.1 to 1.8.2](https://developer.android.com/jetpack/androidx/releases/activity#1.8.2)
