### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,7 +2,7 @@ object Versions {
 
     const val AGP = "8.1.4"
     const val kotlin = "1.9.21"
-    const val coroutines = "1.7.3"
+    const val coroutines = "1.8.0-RC"
     const val KSP = "1.9.21-1.0.15"
     const val material = "1.11.0"
     const val constraintLayout = "2.1.4"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,7 +3,7 @@ object Versions {
     const val AGP = "8.1.4"
     const val kotlin = "1.9.21"
     const val coroutines = "1.8.0-RC"
-    const val KSP = "1.9.21-1.0.15"
+    const val KSP = "1.9.21-1.0.16"
     const val material = "1.11.0"
     const val constraintLayout = "2.1.4"
     const val vbpd = "1.5.9"


### PR DESCRIPTION
Updated:
- [`Kotlin` Coroutines version from 1.7.3 to 1.8.0-RC](https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.8.0-RC)
- [`KSP` version from 1.9.21-1.0.15 to 1.9.21-1.0.16](https://github.com/google/ksp/releases/tag/1.9.21-1.0.16)