### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,7 +2,7 @@ object Versions {
 
     const val AGP = "8.1.4"
     const val kotlin = "1.9.22"
-    const val coroutines = "1.8.0-RC"
+    const val coroutines = "1.8.0-RC2"
     const val KSP = "1.9.21-1.0.16"
     const val material = "1.11.0"
     const val constraintLayout = "2.1.4"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -13,7 +13,7 @@ object Versions {
     const val fragment = "1.6.2"
     const val lifecycle = "2.6.2"
     const val navigation = "2.7.6"
-    const val dagger = "2.49"
+    const val dagger = "2.50"
     const val retrofit = "2.9.0"
     const val moshi = "1.15.0"
     const val okHttp = "4.12.0"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,7 +1,7 @@
 object Versions {
 
     const val AGP = "8.1.4"
-    const val kotlin = "1.9.21"
+    const val kotlin = "1.9.22"
     const val coroutines = "1.8.0-RC"
     const val KSP = "1.9.21-1.0.16"
     const val material = "1.11.0"


### PR DESCRIPTION
Updated:
- [`Kotlin` version from 1.9.21 to 1.9.22](https://github.com/JetBrains/kotlin/releases/tag/v1.9.22)
- [`Kotlin Coroutines` version from 1.8.0-RC to 1.8.0-RC2](https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.8.0-RC2)
- [`Dagger` version from 2.49 to 2.50](https://github.com/google/dagger/releases/tag/dagger-2.50)