### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -11,7 +11,7 @@ object Versions {
     const val splashscreen = "1.0.1"
     const val activity = "1.8.2"
     const val fragment = "1.6.2"
-    const val lifecycle = "2.6.2"
+    const val lifecycle = "2.7.0"
     const val navigation = "2.7.6"
     const val dagger = "2.50"
     const val retrofit = "2.9.0"


### PR DESCRIPTION
Updated:
- [`Lifecycle` version from 2.6.2 to 2.7.0](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.7.0)