### PR TITLE
Update dependencies versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,7 +3,7 @@ object Versions {
     const val AGP = "8.2.2"
     const val kotlin = "1.9.22"
     const val coroutines = "1.8.0-RC2"
-    const val KSP = "1.9.22-1.0.16"
+    const val KSP = "1.9.22-1.0.17"
     const val material = "1.11.0"
     const val constraintLayout = "2.1.4"
     const val vbpd = "1.5.9"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -16,7 +16,7 @@ object Versions {
     const val dagger = "2.50"
     const val retrofit = "2.9.0"
     const val moshi = "1.15.0"
-    const val okHttp = "4.12.0"
+    const val okHttp = "5.0.0-alpha.12"
     const val room = "2.6.1"
     const val paging = "3.2.1"
     const val security = "1.1.0-alpha06"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 object Versions {
 
-    const val AGP = "8.2.1"
+    const val AGP = "8.2.2"
     const val kotlin = "1.9.22"
     const val coroutines = "1.8.0-RC2"
     const val KSP = "1.9.22-1.0.16"


### PR DESCRIPTION
Updated:
- [`AGP` version from 8.2.1 to 8.2.2](https://mvnrepository.com/artifact/com.android.tools.build/gradle/8.2.2)
- [`KSP` version from 1.9.22-1.0.16 to 1.9.22-1.0.17](https://github.com/google/ksp/releases/tag/1.9.22-1.0.17)
- [`OkHttp` version from 4.12.0 to 5.0.0-alpha.12](https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-500-alpha12)