### PR TITLE
Update dependencies versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.3.0"
+agp = "8.3.1"
 kotlin = "1.9.23"
 kotlinx-serialization = "1.6.3"
 coroutines = "1.8.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip


### PR DESCRIPTION
Updated:
- [`Gradle` version from 8.6 to 8.7](https://github.com/gradle/gradle/releases/tag/v8.7.0)
- [`AGP` version from 8.3.0 to 8.3.1](https://mvnrepository.com/artifact/com.android.tools.build/gradle/8.3.1)