### PR TITLE
Migrate – retrofit-kotlinx-serialization-converter

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 
     // Retrofit
     api(libs.retrofit)
-    implementation(libs.retrofit.kotlinx.serialization.converter)
+    implementation(libs.retrofit.converter.kotlinx.serialization)
 
     // OkHttp
     implementation(platform(libs.okHttp.bom))

--- a/core/data/src/main/kotlin/com/alish/boilerplate/data/remote/NetworkFastBuilder.kt
+++ b/core/data/src/main/kotlin/com/alish/boilerplate/data/remote/NetworkFastBuilder.kt
@@ -2,18 +2,18 @@ package com.alish.boilerplate.data.remote
 
 import com.alish.boilerplate.data.BuildConfig
 import com.alish.boilerplate.data.core.utils.jsonClient
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import okhttp3.*
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import java.util.concurrent.TimeUnit
 
 internal fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit = Retrofit.Builder()
     .baseUrl(BuildConfig.BASE_URL)
     .client(okHttpClient)
     .addConverterFactory(
-        jsonClient.asConverterFactory("application/json".toMediaType())
+        jsonClient.asConverterFactory("application/json; charset=UTF8".toMediaType())
     )
     .build()
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,6 @@ lifecycle = "2.7.0"
 navigation = "2.7.7"
 dagger = "2.51.1"
 retrofit = "2.9.0"
-retrofit-kotlinx-serialization = "1.0.0"
 okHttp = "5.0.0-alpha.14"
 room = "2.6.1"
 paging = "3.2.1"
@@ -67,7 +66,7 @@ hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "dag
 
 # Retrofit
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
-retrofit-kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofit-kotlinx-serialization" }
+retrofit-kotlinx-serialization-converter = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
 
 # OkHttp
 okHttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okHttp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ fragment = "1.6.2"
 lifecycle = "2.7.0"
 navigation = "2.7.7"
 dagger = "2.51.1"
-retrofit = "2.9.0"
+retrofit = "2.11.0"
 okHttp = "5.0.0-alpha.14"
 room = "2.6.1"
 paging = "3.2.1"
@@ -66,7 +66,7 @@ hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "dag
 
 # Retrofit
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
-retrofit-kotlinx-serialization-converter = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
+retrofit-converter-kotlinx-serialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
 
 # OkHttp
 okHttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okHttp" }


### PR DESCRIPTION
> DEPRECATED This has moved into Retrofit as a first-party converter. See [here](https://github.com/square/retrofit/tree/trunk/retrofit-converters/kotlinx-serialization) for info.

- [README](https://github.com/JakeWharton/retrofit2-kotlinx-serialization-converter?tab=readme-ov-file#kotlin-serialization-converter) legacy repository
- New `retrofit2-converter-kotlinx-serializtion` [docs](https://github.com/square/retrofit/tree/trunk/retrofit-converters/kotlinx-serialization)

Updated
- [`Retrofit` version from 2.9.0 to 2.11.0](https://github.com/square/retrofit/releases/tag/2.11.0)