### PR TITLE
Update dependencies versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.3.2"
+agp = "8.4.0"
 kotlin = "2.0.0-RC2"
 kotlinx-serialization = "1.6.3"
 kotlinx-coroutines = "1.8.1-Beta"


### PR DESCRIPTION
Updated:
- [`AGP` version from 8.3.2 to 8.4.0](https://developer.android.com/build/releases/gradle-plugin)