### PR TITLE
Update dependencies versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.4.2"
+agp = "8.5.0"
 kotlin = "2.0.0"
 kotlinx-serialization = "1.7.0"
 kotlinx-coroutines = "1.9.0-RC"


### PR DESCRIPTION
Updated:
- `AGP` version from 8.4.2 to 8.5.0
  - [maven](https://mvnrepository.com/artifact/com.android.tools.build/gradle/8.5.0)
  - [release notes](https://developer.android.com/build/releases/gradle-plugin)