### PR TITLE
Update dependencies versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ navigation = "2.7.7"
 dagger = "2.51.1"
 retrofit = "2.11.0"
 okHttp = "5.0.0-alpha.14"
-room = "2.7.0-alpha03"
+room = "2.7.0-alpha04"
 paging = "3.3.0"
 security = "1.1.0-alpha06"
 


### PR DESCRIPTION
Updated:
- [`Room` version from 2.7.0-alpha03 to 2.7.0-alpha04](https://developer.android.com/jetpack/androidx/releases/room#2.7.0-alpha04)