### PR TITLE
Update dependencies versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ navigation = "2.7.7"
 dagger = "2.51.1"
 retrofit = "2.11.0"
 okHttp = "5.0.0-alpha.14"
-room = "2.7.0-alpha04"
+room = "2.7.0-alpha05"
 paging = "3.3.0"
 security = "1.1.0-alpha06"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip


### PR DESCRIPTION
Updated:
- [`Gradle` version from 8.8 to 8.9](https://github.com/gradle/gradle/releases/tag/v8.9.0)
- [`Room` version from 2.7.0-alpha04 to 2.7.0-alpha05](https://developer.android.com/jetpack/androidx/releases/room#2.7.0-alpha05)