### PR TITLE
Update dependencies versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.1"
+agp = "8.5.2"
 kotlin = "2.0.10"
 kotlinx-serialization = "1.7.1"
 kotlinx-coroutines = "1.9.0-RC"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ navigation = "2.7.7"
 dagger = "2.52"
 retrofit = "2.11.0"
 okHttp = "5.0.0-alpha.14"
-room = "2.7.0-alpha05"
+room = "2.7.0-alpha06"
 paging = "3.3.1"
 security = "1.1.0-alpha06"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.5.2"
 kotlin = "2.0.10"
 kotlinx-serialization = "1.7.1"
-kotlinx-coroutines = "1.9.0-RC"
+kotlinx-coroutines = "1.9.0-RC.2"
 ksp = "2.0.10-1.0.24"
 material = "1.12.0"
 constraintLayout = "2.1.4"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ dagger = "2.52"
 retrofit = "2.11.0"
 okHttp = "5.0.0-alpha.14"
 room = "2.7.0-alpha06"
-paging = "3.3.1"
+paging = "3.3.2"
 security = "1.1.0-alpha06"
 
 [libraries]


### PR DESCRIPTION
Updated:
- [`AGP` version from 8.5.1 to 8.5.2](https://mvnrepository.com/artifact/com.android.tools.build/gradle/8.5.2)
- [`Kotlinx Coroutines` version from 1.9.0-RC to 1.9.0-RC.2](https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.9.0-RC.2)
- [`Room` version from 2.7.0-alpha05 to 2.7.0-alpha06](https://developer.android.com/jetpack/androidx/releases/room#2.7.0-alpha06)
- [`Paging` version from 3.3.1 to 3.3.2](https://developer.android.com/jetpack/androidx/releases/paging#3.3.2)