### PR TITLE
Update dependencies versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.2"
+agp = "8.6.0-rc01"
 kotlin = "2.0.10"
 kotlinx-serialization = "1.7.1"
 kotlinx-coroutines = "1.9.0-RC.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip


### PR DESCRIPTION
Updated:
- [`Gradle` version from 8.9 to 8.10](https://github.com/gradle/gradle/releases/tag/v8.10.0)
- [`AGP` version from 8.5.2 ton 8.6.0-rc01](https://mvnrepository.com/artifact/com.android.tools.build/gradle/8.6.0-rc01)