### PR TITLE
Update dependencies versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.6.1"
 kotlin = "2.0.20"
-kotlinx-serialization = "1.7.2"
+kotlinx-serialization = "1.7.3"
 kotlinx-coroutines = "1.9.0"
 ksp = "2.0.20-1.0.25"
 material = "1.12.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.6.0"
+agp = "8.6.1"
 kotlin = "2.0.20"
 kotlinx-serialization = "1.7.2"
 kotlinx-coroutines = "1.9.0-RC.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.6.1"
 kotlin = "2.0.20"
 kotlinx-serialization = "1.7.2"
-kotlinx-coroutines = "1.9.0-RC.2"
+kotlinx-coroutines = "1.9.0"
 ksp = "2.0.20-1.0.25"
 material = "1.12.0"
 constraintLayout = "2.1.4"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip


### PR DESCRIPTION
Updated:
- [`AGP` version from 8.6.0 to 8.6.1](https://mvnrepository.com/artifact/com.android.tools.build/gradle/8.6.1)
- [`Gradle` version from 8.10.1 to 8.10.2](https://github.com/gradle/gradle/releases/tag/v8.10.2)
- [`Kotlinx Coroutines` version from 1.9.0-RC.2 to 1.9.0](https://github.com/gradle/gradle/releases/tag/v8.10.2)
- [`Kotlinx Serialization` version from 1.7.2 to 1.7.3](https://github.com/Kotlin/kotlinx.serialization/releases/tag/v1.7.3)